### PR TITLE
[CLEANUP] - fixing circular dependency between pentaho-karaf-assembly…

### DIFF
--- a/activator/pom.xml
+++ b/activator/pom.xml
@@ -93,7 +93,7 @@
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
-      <artifactId>pdi-osgi-bridge</artifactId>
+      <artifactId>pdi-osgi-bridge-core</artifactId>
       <version>6.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>

--- a/assembly/.gitignore
+++ b/assembly/.gitignore
@@ -1,0 +1,10 @@
+bin/
+dist/
+lib/
+lib-runtime/
+lib-provided/
+lib-deploy/
+target/
+*.iml
+.classpath
+.project

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>pdi-osgi-bridge-assembly</artifactId>
+
+  <packaging>pom</packaging>
+
+  <parent>
+    <groupId>pentaho</groupId>
+    <artifactId>pdi-osgi-bridge-parent</artifactId>
+    <relativePath>../pom.xml</relativePath>
+    <version>6.0-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <package.features>true</package.features>
+    <pentaho-karaf-assembly.version>${project.version}</pentaho-karaf-assembly.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pdi-osgi-bridge-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pdi-osgi-bridge-activator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Uncompress the standard Karaf distribution -->
+            <id>unpack</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>pentaho</groupId>
+                  <artifactId>pentaho-karaf-assembly</artifactId>
+                  <version>${pentaho-karaf-assembly.version}</version>
+                  <classifier>client</classifier>
+                  <type>zip</type>
+                  <outputDirectory>target/dependencies</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>package</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/main/descriptors/assembly.xml</descriptor>
+              </descriptors>
+              <finalName>${project.artifactId}</finalName>
+              <appendAssemblyId>false</appendAssemblyId>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>1.5</version>
+          <executions>
+            <execution>
+              <id>attach-artifacts</id>
+              <phase>package</phase>
+              <goals>
+                <goal>attach-artifact</goal>
+              </goals>
+              <configuration>
+                <artifacts>
+                  <artifact>
+                    <file>target/${project.artifactId}.zip</file>
+                    <type>zip</type>
+                  </artifact>
+
+                </artifacts>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+    </plugins>
+
+  </build>
+  
+</project>

--- a/assembly/src/main/descriptors/assembly.xml
+++ b/assembly/src/main/descriptors/assembly.xml
@@ -22,15 +22,9 @@
   <formats>
     <format>zip</format>
   </formats>
+  <baseDirectory>pdi-osgi-bridge</baseDirectory>
 
   <fileSets>
-    <fileSet>
-      <directory>target</directory>
-      <outputDirectory></outputDirectory>
-      <includes>
-        <include>*.jar</include>
-      </includes>
-    </fileSet>
     <!-- Expanded Karaf Standard Distribution -->
     <fileSet>
       <directory>target/dependencies/pentaho-karaf-assembly</directory>
@@ -50,6 +44,31 @@
   <dependencySets>
     <dependencySet>
       <outputDirectory>/lib</outputDirectory>
+      <excludes>
+        <exclude>pentaho:pdi-osgi-bridge-core:jar:${project.version}</exclude>
+        <exclude>pentaho:pdi-osgi-bridge-activator:jar:${project.version}</exclude>
+        <exclude>*:easymock*</exclude>
+        <exclude>*:jansi*</exclude>
+        <exclude>*:jline*</exclude>
+        <exclude>*:mina-core*</exclude>
+        <exclude>org.osgi:org.osgi.compendium:*</exclude>
+        <exclude>org.apache.felix:*</exclude>
+        <exclude>org.apache.aries.blueprint:*</exclude>
+        <exclude>org.apache.aries.proxy:*</exclude>
+        <exclude>org.apache.aries.quiesce:*</exclude>
+        <exclude>org.apache.karaf*:*</exclude>
+        <exclude>org.ops4j.pax.*:*</exclude>
+        <exclude>*:sshd-core:*</exclude>
+      </excludes>
+      <unpack>false</unpack>
+      <scope>runtime</scope>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <outputDirectory></outputDirectory>
+      <includes>
+        <include>pentaho:pdi-osgi-bridge-core:jar:${project.version}</include>
+      </includes>
       <unpack>false</unpack>
       <scope>runtime</scope>
       <useProjectArtifact>false</useProjectArtifact>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>pdi-osgi-bridge</artifactId>
+  <artifactId>pdi-osgi-bridge-core</artifactId>
 
   <packaging>jar</packaging>
 
@@ -214,79 +214,7 @@
           </check>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- Uncompress the standard Karaf distribution -->
-            <id>unpack</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>pentaho</groupId>
-                  <artifactId>pentaho-karaf-assembly</artifactId>
-                  <version>${pentaho-karaf-assembly.version}</version>
-                  <classifier>client</classifier>
-                  <type>zip</type>
-                  <outputDirectory>target/dependencies</outputDirectory>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.4</version>
-        <executions>
-          <execution>
-            <id>package</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-              <descriptors>
-                <descriptor>src/main/descriptors/assembly.xml</descriptor>
-              </descriptors>
-              <finalName>${project.artifactId}</finalName>
-              <appendAssemblyId>false</appendAssemblyId>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.5</version>
-          <executions>
-            <execution>
-              <id>attach-artifacts</id>
-              <phase>package</phase>
-              <goals>
-                <goal>attach-artifact</goal>
-              </goals>
-              <configuration>
-                <artifacts>
-                  <artifact>
-                    <file>target/${project.artifactId}.zip</file>
-                    <type>zip</type>
-                  </artifact>
-
-                </artifacts>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-
     </plugins>
-
   </build>
   
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <module>activator</module>
     <module>examples/step</module>
     <module>examples/spoon</module>
+    <module>assembly</module>
   </modules>
   <properties>
     <dependency.pentaho-kettle.version>${project.version}</dependency.pentaho-kettle.version>


### PR DESCRIPTION
… and pdi-osgi-bridge.

pdi-osgi-bridge assembly pulled in pentaho-karaf-assembly and pentaho-karaf-assembly (in the standard feature file) pulls in pdi-osgi-bridge-activators. This was the source of the circular dependency and is potentially fixed by splitting out the assembly from the core of the bridge.

@lgrill-pentaho _NOTE: It is still required (by the build) to build the pdi-osgi-bridge core and activator FIRST, then pentaho-karaf-assembly, and LAST the pdi-osgi-bridge assembly._