### PR TITLE
[BACKLOG-5332] Making CapabilityProvider handle features not found in…

### DIFF
--- a/activator/src/main/java/org/pentaho/osgi/bridge/KarafCapabilityProvider.java
+++ b/activator/src/main/java/org/pentaho/osgi/bridge/KarafCapabilityProvider.java
@@ -108,7 +108,12 @@ public class KarafCapabilityProvider extends ServiceTracker<FeaturesService, Fea
 
   @Override public ICapability getCapabilityById( String id ) {
     try {
-      return new KarafCapability( featuresService, featuresService.getFeature( id ), this );
+      Feature feature = featuresService.getFeature( id );
+      if( feature == null ){
+        logger.error( "No feature found matching id: " + id );
+        return null;
+      }
+      return new KarafCapability( featuresService, feature, this );
     } catch ( Exception e ) {
       logger.error( "Unknown error retrieving feature: "+id, e );
     }


### PR DESCRIPTION
… the environment. This results in helpful logging instead of an NPE