### PR TITLE
[PDI-14882] Hang in OSGIPluginTracker caused by concurrent hash map access

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -177,6 +177,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>17.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/core/src/main/java/org/pentaho/di/osgi/OSGIPluginTracker.java
+++ b/core/src/main/java/org/pentaho/di/osgi/OSGIPluginTracker.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.osgi;
 
+import com.google.common.collect.MapMaker;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -58,12 +59,17 @@ public class OSGIPluginTracker {
     private Map<Class, OSGIServiceTracker> trackers = new WeakHashMap<Class, OSGIServiceTracker>();
     private Map<Class, List<OSGIServiceLifecycleListener>> listeners =
             new WeakHashMap<Class, List<OSGIServiceLifecycleListener>>();
-    private Map<Object, ServiceReference> instanceToReferenceMap = new WeakHashMap<Object, ServiceReference>();
-    private Map<ServiceReference, Object> referenceToInstanceMap = new WeakHashMap<ServiceReference, Object>();
-    private Map<BeanFactory, Bundle> beanFactoryToBundleMap = new WeakHashMap<BeanFactory, Bundle>();
-    private Map<Object, BeanFactory> beanToFactoryMap = new WeakHashMap<Object, BeanFactory>();
     private Map<Object, List<ServiceReferenceListener>> instanceListeners =
             new WeakHashMap<Object, List<ServiceReferenceListener>>();
+    // MapMaker provides a ConcurrentMap with weak keys and weak values
+    private Map<Object, ServiceReference> instanceToReferenceMap =
+            new MapMaker().weakKeys().weakValues().makeMap();
+    private Map<ServiceReference, Object> referenceToInstanceMap =
+            new MapMaker().weakKeys().weakValues().makeMap();
+    private Map<BeanFactory, Bundle> beanFactoryToBundleMap =
+            new MapMaker().weakKeys().weakValues().makeMap();
+    private Map<Object, BeanFactory> beanToFactoryMap =
+            new MapMaker().weakKeys().weakValues().makeMap();
     private static ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {

--- a/core/src/test/java/org/pentaho/di/osgi/OSGIPluginTrackerConcurrencyTest.java
+++ b/core/src/test/java/org/pentaho/di/osgi/OSGIPluginTrackerConcurrencyTest.java
@@ -1,0 +1,98 @@
+package org.pentaho.di.osgi;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.pentaho.di.osgi.service.lifecycle.LifecycleEvent;
+import org.pentaho.osgi.api.BeanFactory;
+import org.pentaho.osgi.api.BeanFactoryLocator;
+import org.pentaho.osgi.api.ProxyUnwrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by jason.dyjohnson on 1/25/16.
+ */
+@RunWith(MockitoJUnitRunner.class )
+public class OSGIPluginTrackerConcurrencyTest {
+    private OSGIPluginTracker tracker;
+    private BundleContext bundleContext;
+    @Mock private ProxyUnwrapper mockProxyUnwrapper;
+    private Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Before
+    public void setup() throws InvalidSyntaxException {
+        tracker = new OSGIPluginTracker();
+        tracker.setProxyUnwrapper( mockProxyUnwrapper );
+        bundleContext = mock( BundleContext.class );
+        Filter filter = mock( Filter.class );
+        when( bundleContext.createFilter( anyString())).thenReturn( filter );
+        when( mockProxyUnwrapper.unwrap( anyObject() ) ).thenAnswer( new Answer<Object>() {
+            @Override
+            public Object answer( InvocationOnMock invocation ) throws Throwable {
+                // return the same object that was passed in
+                return invocation.getArguments()[0];
+            }
+        } );
+    }
+
+    @Test
+    public void testGetBeanConcurrently() throws InvalidSyntaxException {
+        tracker.setBundleContext(bundleContext);
+        final Class<Object> clazz = Object.class;
+        ServiceReference serviceReference = mock(ServiceReference.class);
+        BeanFactoryLocator lookup = mock(BeanFactoryLocator.class);
+        BeanFactory beanFactory = mock(BeanFactory.class);
+        Bundle bundle = mock(Bundle.class);
+        when(serviceReference.getBundle()).thenReturn(bundle);
+        when(lookup.getBeanFactory(bundle)).thenReturn(beanFactory);
+        tracker.setBeanFactoryLookup(lookup);
+        ExecutorService executor = Executors.newFixedThreadPool(64);
+        final Object instance = new Object();
+        when(bundleContext.getService(serviceReference)).thenReturn(instance);
+        tracker.serviceChanged(clazz, LifecycleEvent.START, serviceReference);
+        List<Future<Object>> futures = new ArrayList<Future<Object>>();
+        for (int i = 1; i < 10000; ++i) {
+            final String id = "TEST_ID" + Integer.toString(i);
+            Object bean = new Object();
+            when(beanFactory.getInstance(id, clazz)).thenReturn(bean);
+            Future future = executor.submit(new Callable() {
+                @Override
+                public Object call() {
+                    return tracker.getBean(clazz, instance, id);
+                }
+            });
+            futures.add(future);
+        }
+        executor.shutdown();
+        try {
+            Assert.assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
Resolves two issues:
Main issue is the concurrent WeakHashMap access which causes a hang.
Second issue is that the objects in the WeakHashMap will not be released because the value of the WeakHashMap is not a weak reference. We are storing each key as a value in a corresponding WeakHashMap. For example the key object in instanceToReferenceMap is then stored as a value in referenceToInstanceMap (and vice versa) which would prevent the WeakHashMap from automatically removing keys from either.

To fix both problems I have switched the WeakHashMap to Guava ConcurrentMap with weak values and weak keys.