### PR TITLE
[BACKLOG-18996] PDI - Kafka Producer Step - Running a transformation with the Kafka Producer step in Spark or AEL produces a plugin class error

### DIFF
--- a/core/src/main/java/org/pentaho/di/osgi/OSGIPlugin.java
+++ b/core/src/main/java/org/pentaho/di/osgi/OSGIPlugin.java
@@ -207,17 +207,7 @@ public class OSGIPlugin implements PluginInterface, ClassLoadingPluginInterface 
       return classFactoryMap.get( pluginClass ).create( pluginClass );
     }
 
-    // I don't know the usefulness of this, probably matching existing PluginRegistry behavior
-    try {
-      return pluginClass.newInstance();
-    } catch ( Exception e ) {
-      logger.error(
-        "Plugin Class not found in Plugin Class Mapping: " + pluginClass.getName() + " : " + this.getPluginType()
-          + " : "
-          + this.getID() );
-      return null;
-    }
-
+    return null;
   }
 
   public BeanFactory getBeanFactory() {

--- a/core/src/test/java/org/pentaho/di/osgi/OSGIPluginTest.java
+++ b/core/src/test/java/org/pentaho/di/osgi/OSGIPluginTest.java
@@ -31,7 +31,6 @@ import org.pentaho.osgi.api.BeanFactory;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -213,8 +212,7 @@ public class OSGIPluginTest {
   @Test
   public void testLoadClassNotInBeanMap() throws KettlePluginException {
     ArrayList result = osgiPlugin.loadClass( ArrayList.class );
-    assertNotNull( result );
-    assertTrue( result instanceof ArrayList );
+    assertNull( result );
   }
 
   public void testLoadClassInstantiationException() throws KettlePluginException {


### PR DESCRIPTION
Do not try instantiating requested plugin type.

Changed implementation of loadClass method to match the second of 2 ClassLoadingPluginInterface implementors https://github.com/pentaho/pentaho-kettle/blame/master/core/src/main/java/org/pentaho/di/core/plugins/SupplementalPlugin.java#L58
PluginRegistry is updated to check result and throw corresponding exception here: https://github.com/pentaho/pentaho-kettle/pull/4541

@pentaho/ackbar @mkambol @DFieldFL