### PR TITLE
[BACKLOG-27573] - OSGi core scope now is compile to be included in do…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,10 +16,7 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -67,12 +64,7 @@
       <artifactId>org.apache.karaf.main</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.aries.blueprint</groupId>
-      <artifactId>org.apache.aries.blueprint.core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
+   <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
@@ -109,6 +101,11 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.compendium</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
…wnstream transitives.

- OSGi compendium only need for testing. Blueprint packages are already provided by OSGi compendium artifact so removed Aires implementation artifact.