### PR TITLE
[BACKLOG-27577] Centralize karaf dependencies management

### DIFF
--- a/activator/pom.xml
+++ b/activator/pom.xml
@@ -20,6 +20,10 @@
       <artifactId>org.osgi.compendium</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.karaf.features</groupId>
+      <artifactId>org.apache.karaf.features.core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.aries.blueprint</groupId>
       <artifactId>org.apache.aries.blueprint.core</artifactId>
       <scope>provided</scope>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,11 +60,6 @@
       <artifactId>pentaho-osgi-utils-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.karaf</groupId>
-      <artifactId>org.apache.karaf.main</artifactId>
-      <scope>provided</scope>
-    </dependency>
-   <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <commons-xul.version>8.3.0.0-SNAPSHOT</commons-xul.version>
     <guava.version>17.0</guava.version>
     <platform.version>8.3.0.0-SNAPSHOT</platform.version>
-    <karaf.version>3.0.3</karaf.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -91,11 +90,6 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.karaf</groupId>
-        <artifactId>org.apache.karaf.main</artifactId>
-        <version>${karaf.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
         <version>${mockito.version}</version>
@@ -139,17 +133,6 @@
         <groupId>org.ops4j.pax.tinybundles</groupId>
         <artifactId>tinybundles</artifactId>
         <version>${tinybundles.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>org.osgi.core</artifactId>
-            <groupId>org.osgi</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.karaf.features</groupId>
-        <artifactId>org.apache.karaf.features.core</artifactId>
-        <version>${karaf.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>org.osgi.core</artifactId>


### PR DESCRIPTION
@graimundo and @Pancho7 please review.

Note that this targets pentaho:karaf_update, so wingman will not run. Our build pipeline will, when all related PRs are merged.

It goes a bit further and removes unneeded dependencies.

Needs [pentaho/maven-parent-poms#107](https://github.com/pentaho/maven-parent-poms/pull/107).