### PR TITLE
[PPP-4400] Use of Vulnerable Component: logback-classic-1.1.11.jar (CVE-2017-5929)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <tinybundles.version>2.0.0</tinybundles.version>
     <pentaho-osgi-utils.version>${project.version}</pentaho-osgi-utils.version>
-    <logback.version>0.9.29</logback.version>
     <pdi.version>9.0.0.0-SNAPSHOT</pdi.version>
     <exam.version>4.1.0</exam.version>
     <commons-xul.version>9.0.0.0-SNAPSHOT</commons-xul.version>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @wseyler

* [PPP-4400] Remove version reference, letting maven-parent-poms handle it

This Pull Request is part of a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/145
- https://github.com/pentaho/pdi-osgi-bridge/pull/73
- https://github.com/pentaho/pdi-monitoring-plugin/pull/96
- https://github.com/pentaho/pentaho-ee/pull/2128
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/227
- https://github.com/pentaho/pentaho-osgi-bundles/pull/324