### PR TITLE
[PPP-4400] Use of Vulnerable Component: logback-classic-1.1.11.jar (C…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,16 +103,6 @@
         <version>${exam.version}</version>
       </dependency>
       <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.ops4j.pax.exam</groupId>
         <artifactId>pax-exam-cdi</artifactId>
         <version>${exam.version}</version>


### PR DESCRIPTION
…VE-2017-5929)

Dependency management block moved to parent POM.
See: https://github.com/pentaho/maven-parent-poms/pull/145

@ssamora 