### PR TITLE
[SP-5147] Backport of PPP-4400 - Use of Vulnerable Component: logback-classic-1.1.11.jar (CVE-2017-5929) (8.3 Suite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <tinybundles.version>2.0.0</tinybundles.version>
     <pentaho-osgi-utils.version>${project.version}</pentaho-osgi-utils.version>
-    <logback.version>0.9.29</logback.version>
     <pdi.version>8.3.0.0-SNAPSHOT</pdi.version>
     <exam.version>4.1.0</exam.version>
     <commons-xul.version>8.3.0.0-SNAPSHOT</commons-xul.version>
@@ -102,16 +101,6 @@
         <groupId>org.ops4j.pax.exam</groupId>
         <artifactId>pax-exam-link-mvn</artifactId>
         <version>${exam.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
       </dependency>
       <dependency>
         <groupId>org.ops4j.pax.exam</groupId>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @LeonardoCoelho71950 

This PR is a part of a set of PRs:
- https://github.com/pentaho/maven-parent-poms/pull/149
- https://github.com/pentaho/pdi-osgi-bridge/pull/76
- https://github.com/pentaho/pdi-monitoring-plugin/pull/97
- https://github.com/pentaho/adaptive-execution-layer/pull/5
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/228
- https://github.com/pentaho/pentaho-osgi-bundles/pull/325