### PR TITLE
[SP-5146] Backport of PPP-4400 - Use of Vulnerable Component: logback-classic-1.1.11.jar (CVE-2017-5929) (7.1 Suite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
     <aries.util.version>1.1.0</aries.util.version>
     <felix.version>4.4.1</felix.version>
     <guava.version>17.0</guava.version>
-    <logback.version>0.9.29</logback.version>
     <tinybundles.version>2.0.0</tinybundles.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <snakeyaml.version>1.13</snakeyaml.version>
@@ -150,16 +149,6 @@
         <groupId>org.ops4j.pax.url</groupId>
         <artifactId>pax-url-aether</artifactId>
         <version>${pax-url-aether.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
       </dependency>
       <dependency>
         <groupId>org.ops4j.pax.exam</groupId>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @LeonardoCoelho71950

This PR is a part of a set of PRs (pentaho-ee was not backported as the relevant file was added in version 8.0+):
- https://github.com/pentaho/maven-parent-poms/pull/150
- https://github.com/pentaho/pdi-osgi-bridge/pull/77
- https://github.com/pentaho/pdi-monitoring-plugin/pull/98
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/229
- https://github.com/pentaho/pentaho-osgi-bundles/pull/326