### PR TITLE
[BACKLOG-37058] Handle the OSGIActivator being stopped and restarted.

### DIFF
--- a/core/src/main/java/org/pentaho/di/osgi/OSGIActivator.java
+++ b/core/src/main/java/org/pentaho/di/osgi/OSGIActivator.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,6 +29,8 @@ import org.pentaho.di.osgi.service.tracker.BeanFactoryLookupServiceTracker;
 import org.pentaho.di.osgi.service.tracker.PdiPluginSupplementalClassMappingsTrackerForPluginRegistry;
 import org.pentaho.di.osgi.service.tracker.ProxyUnwrapperServiceTracker;
 import org.pentaho.osgi.api.BeanFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * User: nbaker Date: 11/2/10
@@ -40,6 +42,7 @@ public class OSGIActivator implements BundleActivator {
   private ProxyUnwrapperServiceTracker proxyUnwrapperServiceTracker;
   private PdiPluginSupplementalClassMappingsTrackerForPluginRegistry
     pdiPluginSupplementalClassMappingsTrackerForPluginRegistry;
+  private Logger logger = LoggerFactory.getLogger( OSGIActivator.class );
 
   public OSGIActivator() {
     osgiPluginTracker = OSGIPluginTracker.getInstance();
@@ -55,6 +58,7 @@ public class OSGIActivator implements BundleActivator {
   }
 
   @Override public void start( BundleContext bundleContext ) throws Exception {
+    logger.info( "OSGIActivator started" );
     this.bundleContext = bundleContext;
     proxyUnwrapperServiceTracker = new ProxyUnwrapperServiceTracker( bundleContext, osgiPluginTracker );
     proxyUnwrapperServiceTracker.open();
@@ -69,13 +73,16 @@ public class OSGIActivator implements BundleActivator {
 
     // Make sure all activation is done BEFORE this call. It will block until all bundles are registered
     KarafLifecycleListener.getInstance().setBundleContext( bundleContext );
+    logger.info( "OSGIActivator start complete" );
   }
 
   public void stop( BundleContext bundleContext ) throws Exception {
+    logger.info( "OSGIActivator stopped" );
     KarafLifecycleListener.getInstance().setBundleContext( null );
     osgiPluginTracker.shutdown();
     beanFactoryLookupServiceTracker.close();
     proxyUnwrapperServiceTracker.close();
     pdiPluginSupplementalClassMappingsTrackerForPluginRegistry.close();
+    logger.info( "OSGIActivator stop complete" );
   }
 }

--- a/core/src/main/java/org/pentaho/di/osgi/service/notifier/DelayedInstanceNotifier.java
+++ b/core/src/main/java/org/pentaho/di/osgi/service/notifier/DelayedInstanceNotifier.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -63,7 +63,7 @@ public class DelayedInstanceNotifier implements Runnable {
     try {
       factory = osgiPluginTracker.findOrCreateBeanFactoryFor( serviceObject );
     } catch ( OSGIPluginTrackerException e ) {
-      logger.error( "Error getting bean factory", e );
+      logger.warn( "Error getting bean factory. If this error does not self-correct, there may be other startup problems.", e );
     }
     if ( factory == null ) {
       ScheduledFuture<?> timeHandle = scheduler.schedule( this, 2, TimeUnit.SECONDS );

--- a/core/src/test/java/org/pentaho/di/osgi/registryExtension/OSGIPluginRegistryExtensionTest.java
+++ b/core/src/test/java/org/pentaho/di/osgi/registryExtension/OSGIPluginRegistryExtensionTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -80,6 +80,7 @@ public class OSGIPluginRegistryExtensionTest {
   public void testInit() {
     PluginRegistry registry = mock( PluginRegistry.class );
     when( kettleClientEnvironmentInitialized.get() ).thenReturn( true );
+    when( tracker.registerPluginClass( any() ) ).thenReturn( true );
     OSGIPluginRegistryExtension.getInstance().init( registry );
     verify( karafBoot ).startup( null );
     verify( tracker ).registerPluginClass( PluginInterface.class );
@@ -89,6 +90,7 @@ public class OSGIPluginRegistryExtensionTest {
 
   @Test
   public void testSearchForType() {
+    when( tracker.registerPluginClass( any() ) ).thenReturn( true );
     OSGIPluginRegistryExtension.getInstance().searchForType( OSGIPluginType.getInstance() );
     verify( tracker ).registerPluginClass( OSGIPluginType.class );
   }


### PR DESCRIPTION
If the OSGIPluginTracker hits an invalid bundle context, only log it; presumably it'll get kicked off again.
If OSGIPluginRegistryExtension tries to use the OSGIPluginTracker while OSGIActivator is being restarted, wait and try again.  This will hold up system boot, but we do want to wait until karaf is ready.