### PR TITLE
[BACKLOG-37477] The PluginRegistryOSGIServiceLifecycleListener was not

### DIFF
--- a/core/src/main/java/org/pentaho/di/osgi/OSGIActivator.java
+++ b/core/src/main/java/org/pentaho/di/osgi/OSGIActivator.java
@@ -25,6 +25,8 @@ package org.pentaho.di.osgi;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.pentaho.di.core.plugins.PluginInterface;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.osgi.service.lifecycle.PluginRegistryOSGIServiceLifecycleListener;
 import org.pentaho.di.osgi.service.tracker.BeanFactoryLookupServiceTracker;
 import org.pentaho.di.osgi.service.tracker.PdiPluginSupplementalClassMappingsTrackerForPluginRegistry;
 import org.pentaho.di.osgi.service.tracker.ProxyUnwrapperServiceTracker;
@@ -67,6 +69,7 @@ public class OSGIActivator implements BundleActivator {
     osgiPluginTracker.registerPluginClass( PluginInterface.class );
     beanFactoryLookupServiceTracker = new BeanFactoryLookupServiceTracker( bundleContext, osgiPluginTracker );
     beanFactoryLookupServiceTracker.open();
+    osgiPluginTracker.addPluginLifecycleListener( PluginInterface.class, new PluginRegistryOSGIServiceLifecycleListener( PluginRegistry.getInstance() ) );
     pdiPluginSupplementalClassMappingsTrackerForPluginRegistry =
       new PdiPluginSupplementalClassMappingsTrackerForPluginRegistry( bundleContext );
     pdiPluginSupplementalClassMappingsTrackerForPluginRegistry.open();

--- a/core/src/main/java/org/pentaho/di/osgi/registryExtension/OSGIPluginRegistryExtension.java
+++ b/core/src/main/java/org/pentaho/di/osgi/registryExtension/OSGIPluginRegistryExtension.java
@@ -110,14 +110,13 @@ public class OSGIPluginRegistryExtension implements PluginRegistryExtension {
     }
     boolean success = false;
     PluginRegistry.addPluginType( OSGIPluginType.getInstance() );
+    tracker.addPluginLifecycleListener( PluginInterface.class,
+      new PluginRegistryOSGIServiceLifecycleListener( registry ) );
+    logger.info( "Registered lifecycle listener with OSGIPluginTracker" );
     while ( !success ) {
       success = tracker.registerPluginClass( PluginInterface.class );
-      logger.info( "Registered PluginInterface with OSGIPluginTracker" );
-
       if ( success ) {
-        tracker.addPluginLifecycleListener( PluginInterface.class,
-          new PluginRegistryOSGIServiceLifecycleListener( registry ) );
-        logger.info( "Registered lifecycle listener with OSGIPluginTracker" );
+        logger.info( "Registered PluginInterface with OSGIPluginTracker" );
       } else {
         logger.info( "Unable to register PluginInterface with OSGIPluginTracker; waiting and retrying" );
         try {

--- a/core/src/main/java/org/pentaho/di/osgi/service/lifecycle/PluginRegistryOSGIServiceLifecycleListener.java
+++ b/core/src/main/java/org/pentaho/di/osgi/service/lifecycle/PluginRegistryOSGIServiceLifecycleListener.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -56,6 +56,7 @@ public class PluginRegistryOSGIServiceLifecycleListener implements OSGIServiceLi
       try {
         registry.registerPlugin( pluginTypeFromPlugin, serviceObject );
         openServiceTracker( pluginTypeFromPlugin, osgiPlugin);
+        logger.debug( "Registered in PluginRegistry " + osgiPlugin.getID() + " " + osgiPlugin.getName() );
       } catch ( KettlePluginException e ) {
         logger.error( e.getMessage(), e );
       }
@@ -68,6 +69,7 @@ public class PluginRegistryOSGIServiceLifecycleListener implements OSGIServiceLi
 
     try {
       new PdiPluginSupplementalClassMappingsTracker( OSGIPluginTracker.getInstance().getBundleContext(), pluginTypeFromPlugin, osgiPlugin ).open();
+      logger.debug( "PdiPluginSupplementalClassMappingsTracker started " + osgiPlugin.getID() + " " + osgiPlugin.getName() );
     } catch ( InvalidSyntaxException e ) {
       // Should never happen, this is from constructing the filter
       logger.error( "Error constructing filter for Class Mapping Tracker", e );
@@ -80,6 +82,7 @@ public class PluginRegistryOSGIServiceLifecycleListener implements OSGIServiceLi
       OSGIPlugin osgiPlugin = (OSGIPlugin) serviceObject;
       Class<? extends PluginTypeInterface> pluginTypeFromPlugin = osgiPlugin.getPluginType();
       registry.removePlugin( pluginTypeFromPlugin, serviceObject );
+      logger.debug( "REMOVED from PluginRegistry " + osgiPlugin.getID() + " " + osgiPlugin.getName() );
     } catch ( Exception e ) {
       logger.error( "Error notifying listener of plugin removal", e );
     }

--- a/core/src/main/java/org/pentaho/di/osgi/service/tracker/OSGIServiceTracker.java
+++ b/core/src/main/java/org/pentaho/di/osgi/service/tracker/OSGIServiceTracker.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -88,6 +88,8 @@ public class OSGIServiceTracker extends ServiceTracker {
   @Override
   public Object addingService( ServiceReference
                                  reference ) {
+    logger.debug( "Called addingService on tracker " + clazzToTrack.getName() );
+    logger.debug( "total services tracked " + references.size() );
     references.add( reference );
     tracker.serviceChanged( clazzToTrack, LifecycleEvent.START, reference );
     Object retVal = super.addingService( reference );
@@ -97,6 +99,7 @@ public class OSGIServiceTracker extends ServiceTracker {
   @Override
   public void removedService( ServiceReference
                                 reference, Object service ) {
+    logger.debug( "Called removedService on tracker " + clazzToTrack.getName() );
     references.remove( reference );
     // wrapping super call in a method to allow Mockito overriding
     try {
@@ -114,6 +117,7 @@ public class OSGIServiceTracker extends ServiceTracker {
   @Override
   public void modifiedService( ServiceReference
                                  reference, Object service ) {
+    logger.debug( "Called modifiedService on tracker " + clazzToTrack.getName() );
     tracker.serviceChanged( clazzToTrack, LifecycleEvent.MODIFY, reference );
     super.modifiedService( reference, service );
   }

--- a/core/src/test/java/org/pentaho/di/osgi/OSGIPluginTrackerTest.java
+++ b/core/src/test/java/org/pentaho/di/osgi/OSGIPluginTrackerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -340,7 +340,6 @@ public class OSGIPluginTrackerTest {
     when( lookup.getBeanFactory( bundle ) ).thenReturn( beanFactory );
     when( bundleContext.getService( serviceReference ) ).thenReturn( instance );
     tracker.serviceChanged( Object.class, LifecycleEvent.START, serviceReference );
-    verify( listener1 ).pluginAdded( instance );
     verify( listener2 ).pluginAdded( instance );
   }
 

--- a/core/src/test/java/org/pentaho/di/osgi/service/notifier/DelayedServiceNotifierTest.java
+++ b/core/src/test/java/org/pentaho/di/osgi/service/notifier/DelayedServiceNotifierTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.*;
  * Created by bryan on 8/18/14.
  */
 public class DelayedServiceNotifierTest {
-  private Map<Class, List<OSGIServiceLifecycleListener>> instanceListeners;
+  private Map<Class, OSGIServiceLifecycleListener> instanceListeners;
   private ScheduledExecutorService scheduler;
   private OSGIPluginTracker osgiPluginTracker;
   private Object serviceObject;
@@ -56,7 +56,7 @@ public class DelayedServiceNotifierTest {
 
   @Before
   public void setup() {
-    instanceListeners = new HashMap<Class, List<OSGIServiceLifecycleListener>>();
+    instanceListeners = new HashMap<Class, OSGIServiceLifecycleListener>();
     scheduler = mock( ScheduledExecutorService.class );
     osgiPluginTracker = mock( OSGIPluginTracker.class );
     serviceObject = mock( Object.class );
@@ -71,9 +71,7 @@ public class DelayedServiceNotifierTest {
         new DelayedServiceNotifier( osgiPluginTracker, clazz, LifecycleEvent.START, serviceObject,
             instanceListeners, scheduler, delayedServiceNotifierListener );
     OSGIServiceLifecycleListener listener = mock( OSGIServiceLifecycleListener.class );
-    List<OSGIServiceLifecycleListener> listeners =
-        new ArrayList<OSGIServiceLifecycleListener>( Arrays.asList( listener ) );
-    instanceListeners.put( clazz, listeners );
+    instanceListeners.put( clazz, listener );
     BeanFactory beanFactory = mock( BeanFactory.class );
     when( osgiPluginTracker.findOrCreateBeanFactoryFor( serviceObject ) ).thenReturn( beanFactory );
     when( osgiPluginTracker.getProxyUnwrapper() ).thenReturn( proxyUnwrapper );
@@ -87,9 +85,7 @@ public class DelayedServiceNotifierTest {
         new DelayedServiceNotifier( osgiPluginTracker, clazz, LifecycleEvent.STOP, serviceObject,
             instanceListeners, scheduler, delayedServiceNotifierListener );
     OSGIServiceLifecycleListener listener = mock( OSGIServiceLifecycleListener.class );
-    List<OSGIServiceLifecycleListener> listeners =
-        new ArrayList<OSGIServiceLifecycleListener>( Arrays.asList( listener ) );
-    instanceListeners.put( clazz, listeners );
+    instanceListeners.put( clazz, listener );
     BeanFactory beanFactory = mock( BeanFactory.class );
     when( osgiPluginTracker.findOrCreateBeanFactoryFor( serviceObject ) ).thenReturn( beanFactory );
     delayedServiceNotifier.run();
@@ -102,9 +98,7 @@ public class DelayedServiceNotifierTest {
         new DelayedServiceNotifier( osgiPluginTracker, clazz, LifecycleEvent.MODIFY, serviceObject,
             instanceListeners, scheduler, delayedServiceNotifierListener );
     OSGIServiceLifecycleListener listener = mock( OSGIServiceLifecycleListener.class );
-    List<OSGIServiceLifecycleListener> listeners =
-        new ArrayList<OSGIServiceLifecycleListener>( Arrays.asList( listener ) );
-    instanceListeners.put( clazz, listeners );
+    instanceListeners.put( clazz, listener );
     BeanFactory beanFactory = mock( BeanFactory.class );
     when( osgiPluginTracker.findOrCreateBeanFactoryFor( serviceObject ) ).thenReturn( beanFactory );
     when( osgiPluginTracker.getProxyUnwrapper() ).thenReturn( proxyUnwrapper );
@@ -120,9 +114,7 @@ public class DelayedServiceNotifierTest {
           new DelayedServiceNotifier( osgiPluginTracker, clazz, eventType, serviceObject,
               instanceListeners, scheduler, delayedServiceNotifierListener );
       OSGIServiceLifecycleListener listener = mock( OSGIServiceLifecycleListener.class );
-      List<OSGIServiceLifecycleListener> listeners =
-          new ArrayList<OSGIServiceLifecycleListener>( Arrays.asList( listener ) );
-      instanceListeners.put( clazz, listeners );
+      instanceListeners.put( clazz, listener );
       BeanFactory beanFactory = mock( BeanFactory.class );
       when( osgiPluginTracker.findOrCreateBeanFactoryFor( serviceObject ) ).thenReturn( beanFactory );
       delayedServiceNotifier.run();
@@ -157,7 +149,7 @@ public class DelayedServiceNotifierTest {
         new DelayedServiceNotifier( osgiPluginTracker, clazz, LifecycleEvent.START, serviceObject,
             instanceListeners, scheduler, null );
     OSGIServiceLifecycleListener osgiServiceLifecycleListener = mock( OSGIServiceLifecycleListener.class );
-    instanceListeners.put( clazz, new ArrayList<>( Arrays.asList( osgiServiceLifecycleListener ) ) );
+    instanceListeners.put( clazz, osgiServiceLifecycleListener );
     BeanFactory beanFactory = mock( BeanFactory.class );
     when( osgiPluginTracker.findOrCreateBeanFactoryFor( serviceObject ) ).thenReturn( beanFactory );
     when( osgiPluginTracker.getProxyUnwrapper() ).thenReturn( mock( ProxyUnwrapper.class ) );
@@ -173,7 +165,7 @@ public class DelayedServiceNotifierTest {
   @Test
   public void testExceptionFromTracker() throws Exception {
     OSGIServiceLifecycleListener osgiServiceLifecycleListener = mock( OSGIServiceLifecycleListener.class );
-    instanceListeners.put( clazz, new ArrayList<>( Arrays.asList( osgiServiceLifecycleListener ) ) );
+    instanceListeners.put( clazz, osgiServiceLifecycleListener );
 
     DelayedServiceNotifier delayedServiceNotifier =
         new DelayedServiceNotifier( osgiPluginTracker, clazz, LifecycleEvent.START, serviceObject,


### PR DESCRIPTION
getting started fast enough, so some plugins got missed being added to the PluginRegistry during startup.  Changes ensured the listener gets created as soon as possible and also if any serviceChanged events happen for PluginInterface objects and there is no listener to catch them, the event gets retried until successful.