### PR TITLE
[BACKLOG-42944] Provide the ability to specify a list of Kettle plugins that

### DIFF
--- a/core/src/main/java/org/pentaho/di/osgi/KarafLifecycleListener.java
+++ b/core/src/main/java/org/pentaho/di/osgi/KarafLifecycleListener.java
@@ -16,8 +16,12 @@ package org.pentaho.di.osgi;
 import com.google.common.annotations.VisibleForTesting;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.startlevel.FrameworkStartLevel;
+import org.pentaho.di.core.exception.KettlePluginException;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.plugins.PluginTypeInterface;
 import org.pentaho.di.core.util.ExecutorUtil;
 import org.pentaho.di.osgi.service.lifecycle.LifecycleEvent;
 import org.pentaho.di.osgi.service.notifier.DelayedServiceNotifierListener;
@@ -33,7 +37,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -52,6 +62,8 @@ public class KarafLifecycleListener implements IPhasedLifecycleListener<KettleLi
   private BundleContext bundleContext;
   private IPhasedLifecycleEvent<KettleLifecycleEvent> event;
   private Thread watcherThread;
+  private static final Set<String> expectedPluginIds = new HashSet();
+  private static final Map<String, String> seenPluginIds = new ConcurrentHashMap<>();
 
   private final Integer frameworkBeginningStartLevel;
   private FrameworkStartLevel frameworkStartLevel;
@@ -155,6 +167,7 @@ public class KarafLifecycleListener implements IPhasedLifecycleListener<KettleLi
         logger.debug( "Watcher thread started" );
         waitForBundlesStarted();
         waitForBlueprints();
+        waitForKettlePluginsRegistered();
         acceptEventOnDelayedServiceNotifiersDone();
       } );
       watcherThread.setDaemon( true );
@@ -204,6 +217,41 @@ public class KarafLifecycleListener implements IPhasedLifecycleListener<KettleLi
     }
   }
 
+  private synchronized <T> List<T> getAllOsgiServices( Class<T> serviceClass ) {
+    ServiceReference<T>[] serviceReferences = null;
+    List<T> serviceList = new ArrayList<>();
+    try {
+      while ( null == serviceReferences && null != bundleContext && !Thread.currentThread().isInterrupted() ) {
+        this.wait( 100 );
+        serviceReferences = ( ServiceReference<T>[] ) bundleContext.getAllServiceReferences( serviceClass.getName(), null );
+      }
+    } catch ( InterruptedException | IllegalStateException e ) {
+      if ( e instanceof InterruptedException || e.getMessage().startsWith( "Invalid BundleContext" ) ) {
+        logger.debug( String.format( "Watcher thread interrupted waiting for service %s", serviceClass.getName() ) );
+        Thread.currentThread().interrupt();
+      }
+    } catch ( InvalidSyntaxException e ) {
+      // this shouldn't happen since we're not using a filter in getAllServiceReferences
+      logger.error( "Error getting service references", e );
+    }
+    if ( null != serviceReferences ) {
+      try {
+        for ( ServiceReference<?> serviceReference : serviceReferences ) {
+          serviceList.add( ( T ) bundleContext.getService( serviceReference ) );
+        }
+        return serviceList;
+      } catch ( IllegalStateException e ) {
+        if ( e.getMessage().startsWith( "Invalid BundleContext" ) ) {
+          logger.debug( String.format( "Watcher thread interrupted waiting for service %s", serviceClass.getName() ) );
+          Thread.currentThread().interrupt();
+        }
+        return serviceList;
+      }
+    } else {
+      return serviceList;
+    }
+  }
+
   /**
    * Actively wait until features are installed.
    *
@@ -217,16 +265,9 @@ public class KarafLifecycleListener implements IPhasedLifecycleListener<KettleLi
   void waitForFeatures() {
     try {
       Thread.sleep( 100 );
-      IKarafFeatureWatcher karafFeatureWatcher = getOsgiService( IKarafFeatureWatcher.class );
-      if ( karafFeatureWatcher == null ) {
-        if ( null != bundleContext && !Thread.currentThread().isInterrupted() ) {
-          throw new IKarafFeatureWatcher.FeatureWatcherException( "No IKarafFeatureWatcher service available." );
-        } else if ( Thread.currentThread().isInterrupted() ) {
-          logger.debug( "Thread interrupted itself because bundle context was invalid; bundle likely restarting" );
-        }
-      } else {
-        karafFeatureWatcher.waitForFeatures();
-      }
+      IKarafFeatureWatcher karafFeatureWatcher = getKarafFeatureWatcher();
+      logger.debug( "Start waiting for features" );
+      karafFeatureWatcher.waitForFeatures();
     } catch ( IKarafFeatureWatcher.FeatureWatcherException e ) {
       if ( null != bundleContext && !( e.getCause() instanceof InterruptedException ) ) {
         logger.error( "Error in Feature Watcher", e );
@@ -252,6 +293,7 @@ public class KarafLifecycleListener implements IPhasedLifecycleListener<KettleLi
           logger.debug( "Thread interrupted itself because bundle context was invalid; bundle likely restarting" );
         }
       } else {
+        logger.debug( "Start waiting for blueprints" );
         karafBlueprintWatcher.waitForBlueprint();
       }
     } catch ( IKarafBlueprintWatcher.BlueprintWatcherException e ) {
@@ -267,6 +309,82 @@ public class KarafLifecycleListener implements IPhasedLifecycleListener<KettleLi
     }
   }
 
+  void waitForKettlePluginsRegistered() {
+    try {
+      Thread.sleep( 100 );
+      if ( expectedPluginIds.isEmpty() ) {
+        IKarafFeatureWatcher karafFeatureWatcher = getKarafFeatureWatcher();
+        // this is safe because if the karafFeatureWatcher returned would be null, the previous method would throw an exception
+        expectedPluginIds.addAll( karafFeatureWatcher.getFeatures( "org.pentaho.features",  "waitForPlugins" ) );
+      }
+      logger.debug( "Start waiting for {} kettle plugins", expectedPluginIds.size() );
+
+      while( !seenAllPlugins() ) {
+        Set<String> missingPlugins = new HashSet<>();
+        missingPlugins.addAll( expectedPluginIds );
+        missingPlugins.removeAll( seenPluginIds.keySet() );
+
+        // check if any plugin bundles were started before the listeners were running or were otherwise missed
+        List<OSGIPlugin> pluginsInKaraf = getAllOsgiServices( OSGIPlugin.class );
+        for ( OSGIPlugin osgiPlugin : pluginsInKaraf ) {
+          String pluginId = osgiPlugin.getID();
+          if ( missingPlugins.contains( pluginId ) ) {
+            // register the plugin with kettle
+            Class<? extends PluginTypeInterface> pluginTypeFromPlugin = osgiPlugin.getPluginType();
+            PluginRegistry.getInstance().registerPlugin( pluginTypeFromPlugin, osgiPlugin );
+            seenPluginIds.put( pluginId, pluginId );
+            logger.debug( "KarafLifecycleListener registered plugin: {}", pluginId );
+          }
+        }
+
+        if ( logger.isInfoEnabled() ) {
+          // recalculate missing plugins list
+          Set<String> missingPlugins2 = new HashSet<>();
+          missingPlugins2.addAll( expectedPluginIds );
+          missingPlugins2.removeAll( seenPluginIds.keySet() );
+          String remainingPluginList = missingPlugins2.stream().reduce( "", ( a, b ) -> a + "," + b );
+          logger.info( "Waiting for the following plugins: {}", remainingPluginList );
+        }
+
+        Thread.sleep( 1000 );
+      }
+    } catch ( IKarafFeatureWatcher.FeatureWatcherException e ) {
+      if ( null != bundleContext && !( e.getCause() instanceof InterruptedException ) ) {
+        logger.error( "Error in Feature Watcher", e );
+      } else if ( e.getCause() instanceof InterruptedException ) {
+        logger.debug( "Watcher thread interrupted during karafFeatureWatcher.waitForKettlePluginsRegistered" );
+        Thread.currentThread().interrupt();
+      }
+    } catch ( InterruptedException e ) {
+      logger.debug( "Watcher thread interrupted during waitForKettlePluginsRegistered" );
+      Thread.currentThread().interrupt();
+    } catch ( IOException e ) {
+      logger.error( "Exception reading list of Kettle plugins to wait for", e );
+    } catch ( KettlePluginException e ) {
+      logger.error( "Error trying to register plugin late", e );
+    }
+  }
+
+  private IKarafFeatureWatcher getKarafFeatureWatcher() throws IKarafFeatureWatcher.FeatureWatcherException {
+    IKarafFeatureWatcher karafFeatureWatcher = getOsgiService( IKarafFeatureWatcher.class );
+    if ( karafFeatureWatcher == null ) {
+      if ( null != bundleContext && !Thread.currentThread().isInterrupted() ) {
+        throw new IKarafFeatureWatcher.FeatureWatcherException( "No IKarafFeatureWatcher service available." );
+      } else if ( Thread.currentThread().isInterrupted() ) {
+        logger.debug( "Thread interrupted itself because bundle context was invalid; bundle likely restarting" );
+      }
+    }
+    return karafFeatureWatcher;
+  }
+
+  public static void pluginIdRegistered( String id ) {
+    seenPluginIds.put( id, id );
+  }
+
+  private static boolean seenAllPlugins()  {
+    return seenPluginIds.keySet().containsAll( expectedPluginIds );
+  }
+
   @VisibleForTesting
   void acceptEventOnDelayedServiceNotifiersDone() {
     try {
@@ -275,7 +393,10 @@ public class KarafLifecycleListener implements IPhasedLifecycleListener<KettleLi
         final AtomicBoolean accepted = new AtomicBoolean( false );
         DelayedServiceNotifierListener delayedServiceNotifierListener = new DelayedServiceNotifierListener() {
           @Override public void onRun( LifecycleEvent lifecycleEvent, Object serviceObject ) {
-            if ( osgiPluginTracker.getOutstandingServiceNotifierListeners() == 0 && !accepted.getAndSet( true ) ) {
+            logger.debug( "Listeners left2 : {}", osgiPluginTracker.getOutstandingServiceNotifierListeners() );
+            // proceed if we found the entire expected list or it was empty but startup is complete otherwise
+            if ( !expectedPluginIds.isEmpty()
+              || ( osgiPluginTracker.getOutstandingServiceNotifierListeners() == 0 && !accepted.getAndSet( true ) ) ) {
               logger.debug( "Done waiting on delayed service notifiers" );
               event.accept();
               releaseBootLock();
@@ -285,6 +406,7 @@ public class KarafLifecycleListener implements IPhasedLifecycleListener<KettleLi
         };
 
         logger.debug( "About to start waiting on delayed service notifiers" );
+        logger.debug( "Listeners left1 : {}", osgiPluginTracker.getOutstandingServiceNotifierListeners() );
         osgiPluginTracker.addDelayedServiceNotifierListener( delayedServiceNotifierListener );
         delayedServiceNotifierListener.onRun( null, null );
       }

--- a/core/src/main/java/org/pentaho/di/osgi/OSGIPluginTracker.java
+++ b/core/src/main/java/org/pentaho/di/osgi/OSGIPluginTracker.java
@@ -248,8 +248,10 @@ public class OSGIPluginTracker {
       logger.debug( "BeanFactoryLookup is currently not set, returning null" );
       return null;
     }
+    logger.debug( "Got lookup {}", serviceObject instanceof OSGIPlugin ? (( OSGIPlugin )serviceObject).getID() : serviceObject);
 
     ServiceReference reference = instanceToReferenceMap.get( serviceObject );
+    logger.debug( "Got reference {}", reference );
     if ( reference == null ) {
       // serviceObject might already be a blueprint container
       BeanFactory beanFactory = lookup.getBeanFactory( serviceObject );
@@ -259,6 +261,7 @@ public class OSGIPluginTracker {
       return beanFactory;
     }
     Bundle objectBundle = reference.getBundle();
+    logger.debug( "Got bundle {}", objectBundle );
     if ( objectBundle == null ) {
       throw new OSGIPluginTrackerException( "Service's Bundle is null, service no longer valid." );
     }
@@ -266,6 +269,7 @@ public class OSGIPluginTracker {
     if ( factory == null ) {
       return null;
     }
+    logger.debug( "Got factory {}", factory );
     beanFactoryToBundleMap.put( factory, objectBundle );
     return factory;
   }
@@ -390,20 +394,24 @@ public class OSGIPluginTracker {
     }
     instanceToReferenceMap.put( instance, serviceObject );
     referenceToInstanceMap.put( serviceObject, instance );
+    logger.debug( "Adding DelayedServiceNotifier for {}", cls.getName() );
     aggregatingNotifierListener.incrementCount();
 
     new DelayedServiceNotifier( this, cls, evt, instance, listeners, scheduler, aggregatingNotifierListener ).run();
   }
 
   public boolean addDelayedServiceNotifierListener( DelayedServiceNotifierListener delayedServiceNotifierListener ) {
+    logger.debug( "Adding listener, count before {}", aggregatingNotifierListener.getCount() );
     return aggregatingNotifierListener.addListener( delayedServiceNotifierListener );
   }
 
   public boolean removeDelayedServiceNotifierListener( DelayedServiceNotifierListener delayedServiceNotifierListener ) {
+    logger.debug( "Removing listener, count before {}", aggregatingNotifierListener.getCount() );
     return aggregatingNotifierListener.removeListener( delayedServiceNotifierListener );
   }
 
   public int getOutstandingServiceNotifierListeners() {
+    logger.debug( "Listener count {}", aggregatingNotifierListener.getCount() );
     return aggregatingNotifierListener.getCount();
   }
 

--- a/core/src/main/java/org/pentaho/di/osgi/service/lifecycle/PluginRegistryOSGIServiceLifecycleListener.java
+++ b/core/src/main/java/org/pentaho/di/osgi/service/lifecycle/PluginRegistryOSGIServiceLifecycleListener.java
@@ -13,6 +13,7 @@
 
 package org.pentaho.di.osgi.service.lifecycle;
 
+import org.pentaho.di.osgi.KarafLifecycleListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.osgi.framework.InvalidSyntaxException;
@@ -46,6 +47,7 @@ public class PluginRegistryOSGIServiceLifecycleListener implements OSGIServiceLi
       Class<? extends PluginTypeInterface> pluginTypeFromPlugin = osgiPlugin.getPluginType();
       try {
         registry.registerPlugin( pluginTypeFromPlugin, serviceObject );
+        KarafLifecycleListener.pluginIdRegistered( osgiPlugin.getID() );
         openServiceTracker( pluginTypeFromPlugin, osgiPlugin);
         logger.debug( "Registered in PluginRegistry " + osgiPlugin.getID() + " " + osgiPlugin.getName() );
       } catch ( KettlePluginException e ) {

--- a/core/src/test/java/org/pentaho/di/osgi/KarafLifecycleListenerTest.java
+++ b/core/src/test/java/org/pentaho/di/osgi/KarafLifecycleListenerTest.java
@@ -173,7 +173,7 @@ public class KarafLifecycleListenerTest {
     when( bundleContext.getServiceReference( IKarafFeatureWatcher.class ) ).thenReturn( featureWatcherServiceReference );
     when( bundleContext.getServiceReference( IKarafBlueprintWatcher.class ) ).thenReturn( blueprintWatcherServiceReference );
 
-    when( osgiPluginTracker.getOutstandingServiceNotifierListeners() ).thenReturn( 1 ).thenReturn( 0 );
+    when( osgiPluginTracker.getOutstandingServiceNotifierListeners() ).thenReturn( 1 ).thenReturn( 1 ).thenReturn( 1 ).thenReturn( 0 );
     karafLifecycleListener.onPhaseChange( iPhasedLifecycleEvent );
     ArgumentCaptor<DelayedServiceNotifierListener> delayedServiceNotifierListenerArgumentCaptor =
       ArgumentCaptor.forClass( DelayedServiceNotifierListener.class );

--- a/core/src/test/java/org/pentaho/di/osgi/OSGIPluginTrackerConcurrencyTest.java
+++ b/core/src/test/java/org/pentaho/di/osgi/OSGIPluginTrackerConcurrencyTest.java
@@ -74,7 +74,7 @@ public class OSGIPluginTrackerConcurrencyTest {
     @Test
     public void testGetBeanConcurrently() throws InvalidSyntaxException {
         tracker.setBundleContext(bundleContext);
-        final Class<Object> clazz = Object.class;
+        final Class<OSGIPlugin> clazz = OSGIPlugin.class;
         ServiceReference serviceReference = mock(ServiceReference.class);
         BeanFactoryLocator lookup = mock(BeanFactoryLocator.class);
         BeanFactory beanFactory = mock(BeanFactory.class);
@@ -82,13 +82,13 @@ public class OSGIPluginTrackerConcurrencyTest {
         when(serviceReference.getBundle()).thenReturn(bundle);
         tracker.setBeanFactoryLookup(lookup);
         ExecutorService executor = Executors.newFixedThreadPool(64);
-        final Object instance = new Object();
+        final OSGIPlugin instance = new OSGIPlugin();
         when(bundleContext.getService(serviceReference)).thenReturn(instance);
         tracker.serviceChanged(clazz, LifecycleEvent.START, serviceReference);
         List<Future<Object>> futures = new ArrayList<Future<Object>>();
         for (int i = 1; i < 10000; ++i) {
             final String id = "TEST_ID" + Integer.toString(i);
-            Object bean = new Object();
+            OSGIPlugin bean = new OSGIPlugin();
             Future future = executor.submit(new Callable() {
                 @Override
                 public Object call() {

--- a/core/src/test/java/org/pentaho/di/osgi/OSGIPluginTrackerTest.java
+++ b/core/src/test/java/org/pentaho/di/osgi/OSGIPluginTrackerTest.java
@@ -130,7 +130,7 @@ public class OSGIPluginTrackerTest {
   @Test
   public void testGetBeanNotNullFactory() {
     tracker.setBundleContext( bundleContext );
-    Class<Object> clazz = Object.class;
+    Class<OSGIPlugin> clazz = OSGIPlugin.class;
     ServiceReference serviceReference = mock( ServiceReference.class );
     BeanFactoryLocator lookup = mock( BeanFactoryLocator.class );
     BeanFactory beanFactory = mock( BeanFactory.class );
@@ -138,11 +138,11 @@ public class OSGIPluginTrackerTest {
     when( serviceReference.getBundle() ).thenReturn( bundle );
     when( lookup.getBeanFactory( bundle ) ).thenReturn( beanFactory );
     tracker.setBeanFactoryLookup( lookup );
-    Object instance = new Object();
+    OSGIPlugin instance = new OSGIPlugin();
     String id = "TEST_ID";
     when( bundleContext.getService( serviceReference ) ).thenReturn( instance );
     tracker.serviceChanged( clazz, LifecycleEvent.START, serviceReference );
-    Object bean = new Object();
+    OSGIPlugin bean = new OSGIPlugin();
     when( beanFactory.getInstance( id, clazz ) ).thenReturn( bean );
     assertEquals( bean, tracker.getBean( clazz, instance, id ) );
   }
@@ -157,7 +157,7 @@ public class OSGIPluginTrackerTest {
     Logger logger = mock( Logger.class );
     tracker.setLogger( logger );
     tracker.setBundleContext( bundleContext );
-    Class<Object> clazz = Object.class;
+    Class<OSGIPlugin> clazz = OSGIPlugin.class;
     ServiceReference serviceReference = mock( ServiceReference.class );
     BeanFactoryLocator lookup = mock( BeanFactoryLocator.class );
     BeanFactory beanFactory = mock( BeanFactory.class );
@@ -168,11 +168,11 @@ public class OSGIPluginTrackerTest {
     when( serviceReference.getBundle() ).thenReturn( bundle );
     when( lookup.getBeanFactory( bundle ) ).thenReturn( beanFactory );
     tracker.setBeanFactoryLookup( lookup );
-    Object instance = new Object();
+    OSGIPlugin instance = new OSGIPlugin();
     String id = "TEST_ID";
     when( bundleContext.getService( serviceReference ) ).thenReturn( instance );
     tracker.serviceChanged( clazz, LifecycleEvent.START, serviceReference );
-    Object bean = new Object();
+    OSGIPlugin bean = new OSGIPlugin();
     when( beanFactory.getInstance( id, clazz ) ).thenReturn( bean );
     ServiceReference ref = mock( ServiceReference.class );
     OSGIPlugin plugin = new OSGIPlugin();
@@ -186,7 +186,7 @@ public class OSGIPluginTrackerTest {
   @Test
   public void testGetBeanPluginPropertySuccess() throws InvalidSyntaxException {
     tracker.setBundleContext( bundleContext );
-    Class<Object> clazz = Object.class;
+    Class<OSGIPlugin> clazz = OSGIPlugin.class;
     ServiceReference serviceReference = mock( ServiceReference.class );
     BeanFactoryLocator lookup = mock( BeanFactoryLocator.class );
     BeanFactory beanFactory = mock( BeanFactory.class );
@@ -194,11 +194,11 @@ public class OSGIPluginTrackerTest {
     when( serviceReference.getBundle() ).thenReturn( bundle );
     when( lookup.getBeanFactory( bundle ) ).thenReturn( beanFactory );
     tracker.setBeanFactoryLookup( lookup );
-    Object instance = new Object();
+    OSGIPlugin instance = new OSGIPlugin();
     String id = "TEST_ID";
     when( bundleContext.getService( serviceReference ) ).thenReturn( instance );
     tracker.serviceChanged( clazz, LifecycleEvent.START, serviceReference );
-    Object bean = new Object();
+    OSGIPlugin bean = new OSGIPlugin();
     when( beanFactory.getInstance( id, clazz ) ).thenReturn( bean );
     BundleContext cxt = mock( BundleContext.class );
     when( bundle.getBundleContext() ).thenReturn( cxt );
@@ -217,7 +217,7 @@ public class OSGIPluginTrackerTest {
   @Test
   public void testGetBeanPluginPropertyNoRefs() throws InvalidSyntaxException {
     tracker.setBundleContext( bundleContext );
-    Class<Object> clazz = Object.class;
+    Class<OSGIPlugin> clazz = OSGIPlugin.class;
     ServiceReference serviceReference = mock( ServiceReference.class );
     BeanFactoryLocator lookup = mock( BeanFactoryLocator.class );
     BeanFactory beanFactory = mock( BeanFactory.class );
@@ -225,11 +225,11 @@ public class OSGIPluginTrackerTest {
     when( serviceReference.getBundle() ).thenReturn( bundle );
     when( lookup.getBeanFactory( bundle ) ).thenReturn( beanFactory );
     tracker.setBeanFactoryLookup( lookup );
-    Object instance = new Object();
+    OSGIPlugin instance = new OSGIPlugin();
     String id = "TEST_ID";
     when( bundleContext.getService( serviceReference ) ).thenReturn( instance );
     tracker.serviceChanged( clazz, LifecycleEvent.START, serviceReference );
-    Object bean = new Object();
+    OSGIPlugin bean = new OSGIPlugin();
     when( beanFactory.getInstance( id, clazz ) ).thenReturn( bean );
     BundleContext cxt = mock( BundleContext.class );
     when( bundle.getBundleContext() ).thenReturn( cxt );
@@ -243,7 +243,7 @@ public class OSGIPluginTrackerTest {
   @Test
   public void testGetBeanPluginPropertyNullRefs() throws InvalidSyntaxException {
     tracker.setBundleContext( bundleContext );
-    Class<Object> clazz = Object.class;
+    Class<OSGIPlugin> clazz = OSGIPlugin.class;
     ServiceReference serviceReference = mock( ServiceReference.class );
     BeanFactoryLocator lookup = mock( BeanFactoryLocator.class );
     BeanFactory beanFactory = mock( BeanFactory.class );
@@ -251,11 +251,11 @@ public class OSGIPluginTrackerTest {
     when( serviceReference.getBundle() ).thenReturn( bundle );
     when( lookup.getBeanFactory( bundle ) ).thenReturn( beanFactory );
     tracker.setBeanFactoryLookup( lookup );
-    Object instance = new Object();
+    OSGIPlugin instance = new OSGIPlugin();
     String id = "TEST_ID";
     when( bundleContext.getService( serviceReference ) ).thenReturn( instance );
     tracker.serviceChanged( clazz, LifecycleEvent.START, serviceReference );
-    Object bean = new Object();
+    OSGIPlugin bean = new OSGIPlugin();
     when( beanFactory.getInstance( id, clazz ) ).thenReturn( bean );
     BundleContext cxt = mock( BundleContext.class );
     when( bundle.getBundleContext() ).thenReturn( cxt );
@@ -268,15 +268,15 @@ public class OSGIPluginTrackerTest {
 
   @Test
   public void testGetClassLoaderNull() {
-    assertNull( tracker.getClassLoader( new Object() ) );
+    assertNull( tracker.getClassLoader( new OSGIPlugin() ) );
   }
 
   @Test
   public void testGetClassLoaderSuccess() {
     tracker.setBundleContext( bundleContext );
-    Class<Object> clazz = Object.class;
+    Class<OSGIPlugin> clazz = OSGIPlugin.class;
     ServiceReference serviceReference = mock( ServiceReference.class );
-    Object instance = new Object();
+    OSGIPlugin instance = new OSGIPlugin();
     when( bundleContext.getService( serviceReference ) ).thenReturn( instance );
     Bundle bundle = mock( Bundle.class );
     when( serviceReference.getBundle() ).thenReturn( bundle );
@@ -291,9 +291,9 @@ public class OSGIPluginTrackerTest {
     tracker.setBundleContext( bundleContext );
     String message = "EXCEPTION_MESSAGE";
     RuntimeException e = new RuntimeException( message );
-    Class<Object> clazz = Object.class;
+    Class<OSGIPlugin> clazz = OSGIPlugin.class;
     ServiceReference serviceReference = mock( ServiceReference.class );
-    Object instance = new Object();
+    OSGIPlugin instance = new OSGIPlugin();
     when( bundleContext.getService( serviceReference ) ).thenReturn( instance );
     when( serviceReference.getBundle() ).thenThrow( e );
     tracker.serviceChanged( clazz, LifecycleEvent.START, serviceReference );
@@ -315,38 +315,38 @@ public class OSGIPluginTrackerTest {
     BeanFactoryLocator lookup = mock( BeanFactoryLocator.class );
     tracker.setBeanFactoryLookup( lookup );
     OSGIServiceLifecycleListener listener1 = mock( OSGIServiceLifecycleListener.class );
-    tracker.addPluginLifecycleListener( Object.class, listener1 );
+    tracker.addPluginLifecycleListener( OSGIPlugin.class, listener1 );
     OSGIServiceLifecycleListener listener2 = mock( OSGIServiceLifecycleListener.class );
-    tracker.addPluginLifecycleListener( Object.class, listener2 );
-    Object instance = new Object();
+    tracker.addPluginLifecycleListener( OSGIPlugin.class, listener2 );
+    OSGIPlugin instance = new OSGIPlugin();
     Bundle bundle = mock( Bundle.class );
     ServiceReference serviceReference = mock( ServiceReference.class );
     when( serviceReference.getBundle() ).thenReturn( bundle );
     BeanFactory beanFactory = mock( BeanFactory.class );
     when( lookup.getBeanFactory( bundle ) ).thenReturn( beanFactory );
     when( bundleContext.getService( serviceReference ) ).thenReturn( instance );
-    tracker.serviceChanged( Object.class, LifecycleEvent.START, serviceReference );
+    tracker.serviceChanged( OSGIPlugin.class, LifecycleEvent.START, serviceReference );
     verify( listener2 ).pluginAdded( instance );
   }
 
   @Test
   public void testSetBundleContextWithQueue() {
-    tracker.registerPluginClass( Object.class );
+    tracker.registerPluginClass( OSGIPlugin.class );
     assertEquals( 0, tracker.getTrackers().size() );
     tracker.setBundleContext( bundleContext );
     assertEquals( 1, tracker.getTrackers().size() );
-    assertEquals( Object.class, new ArrayList<Class>( tracker.getTrackers().keySet() ).get( 0 ) );
+    assertEquals( OSGIPlugin.class, new ArrayList<Class>( tracker.getTrackers().keySet() ).get( 0 ) );
   }
 
   @Test
   public void testRegisterPluginClassAlreadyTracking() {
     tracker.setBundleContext( bundleContext );
-    tracker.registerPluginClass( Object.class );
+    tracker.registerPluginClass( OSGIPlugin.class );
     assertEquals( 1, tracker.getTrackers().size() );
-    assertEquals( Object.class, new ArrayList<Class>( tracker.getTrackers().keySet() ).get( 0 ) );
-    assertTrue( tracker.registerPluginClass( Object.class ) );
+    assertEquals( OSGIPlugin.class, new ArrayList<Class>( tracker.getTrackers().keySet() ).get( 0 ) );
+    assertTrue( tracker.registerPluginClass( OSGIPlugin.class ) );
     assertEquals( 1, tracker.getTrackers().size() );
-    assertEquals( Object.class, new ArrayList<Class>( tracker.getTrackers().keySet() ).get( 0 ) );
+    assertEquals( OSGIPlugin.class, new ArrayList<Class>( tracker.getTrackers().keySet() ).get( 0 ) );
   }
 
   @Test
@@ -365,15 +365,15 @@ public class OSGIPluginTrackerTest {
 
   @Test
   public void testGetOutstandingServiceNotifierListeners() {
-    when( aggregatingNotifierListener.getCount() ).thenReturn( 1 ).thenReturn( 2 );
+    when( aggregatingNotifierListener.getCount() ).thenReturn( 1 ).thenReturn( 1 ).thenReturn( 2 ).thenReturn( 2 );
     assertEquals( 1, tracker.getOutstandingServiceNotifierListeners() );
     assertEquals( 2, tracker.getOutstandingServiceNotifierListeners() );
   }
 
   @Test
   public void testServiceChangedAggregatingListenerInteraction() {
-    String instance = "instance";
-    ServiceReference<String> serviceReference = mock( ServiceReference.class );
+    OSGIPlugin instance = new OSGIPlugin();
+    ServiceReference<OSGIPlugin> serviceReference = mock( ServiceReference.class );
     BeanFactoryLocator beanFactoryLocator = mock( BeanFactoryLocator.class );
     Bundle bundle = mock( Bundle.class );
     BeanFactory beanFactory = mock( BeanFactory.class );
@@ -383,14 +383,14 @@ public class OSGIPluginTrackerTest {
     when( beanFactoryLocator.getBeanFactory( bundle ) ).thenReturn( beanFactory );
     tracker.setBundleContext( bundleContext );
     tracker.setBeanFactoryLookup( beanFactoryLocator );
-    tracker.serviceChanged( String.class, LifecycleEvent.START, serviceReference );
+    tracker.serviceChanged( OSGIPlugin.class, LifecycleEvent.START, serviceReference );
     verify( aggregatingNotifierListener ).incrementCount();
     verify( aggregatingNotifierListener ).onRun( LifecycleEvent.START, instance );
   }
 
   @Test
   public void findOrCreateBeanFactoryFor() throws Exception {
-    String instance = "instance";
+    OSGIPlugin instance = new OSGIPlugin();
     BeanFactory beanFactoryFor = tracker.findOrCreateBeanFactoryFor( instance );
     assertNull( beanFactoryFor );
     BeanFactoryLocator locator = mock( BeanFactoryLocator.class );
@@ -401,13 +401,13 @@ public class OSGIPluginTrackerTest {
     } catch ( OSGIPluginTrackerException expected ) {
     }
 
-    ServiceReference<String> serviceReference = mock( ServiceReference.class );
+    ServiceReference<OSGIPlugin> serviceReference = mock( ServiceReference.class );
     BeanFactoryLocator beanFactoryLocator = mock( BeanFactoryLocator.class );
     when( bundleContext.getService( serviceReference ) ).thenReturn( instance );
     when( serviceReference.getBundle() ).thenReturn( null );
     tracker.setBundleContext( bundleContext );
     tracker.setBeanFactoryLookup( beanFactoryLocator );
-    tracker.serviceChanged( String.class, LifecycleEvent.START, serviceReference );
+    tracker.serviceChanged( OSGIPlugin.class, LifecycleEvent.START, serviceReference );
     try {
       tracker.findOrCreateBeanFactoryFor( instance );
       fail( "Should have thrown an OSGIPluginTrackerException" );
@@ -420,8 +420,8 @@ public class OSGIPluginTrackerTest {
 
   @Test
   public void testInvalidBundleContextOnServiceRemoved() {
-    String instance = "instance";
-    ServiceReference<String> serviceReference = mock( ServiceReference.class );
+    OSGIPlugin instance = new OSGIPlugin();
+    ServiceReference<OSGIPlugin> serviceReference = mock( ServiceReference.class );
     BeanFactoryLocator beanFactoryLocator = mock( BeanFactoryLocator.class );
     Bundle bundle = mock( Bundle.class );
     BeanFactory beanFactory = mock( BeanFactory.class );
@@ -431,12 +431,12 @@ public class OSGIPluginTrackerTest {
     when( beanFactoryLocator.getBeanFactory( bundle ) ).thenReturn( beanFactory );
     tracker.setBundleContext( bundleContext );
     tracker.setBeanFactoryLookup( beanFactoryLocator );
-    tracker.serviceChanged( String.class, LifecycleEvent.START, serviceReference );
+    tracker.serviceChanged( OSGIPlugin.class, LifecycleEvent.START, serviceReference );
 
     // Now invalidate the bundleContext and send a Stop event
 
     when( bundleContext.getService( serviceReference ) ).thenThrow( new IllegalStateException( "BundleContext Invalid" ) );
-    tracker.serviceChanged( String.class, LifecycleEvent.STOP, serviceReference );
+    tracker.serviceChanged( OSGIPlugin.class, LifecycleEvent.STOP, serviceReference );
 
     verify( aggregatingNotifierListener, times(1) ).onRun( LifecycleEvent.STOP, instance );
 

--- a/core/src/test/java/org/pentaho/di/osgi/service/notifier/DelayedServiceNotifierTest.java
+++ b/core/src/test/java/org/pentaho/di/osgi/service/notifier/DelayedServiceNotifierTest.java
@@ -15,6 +15,7 @@ package org.pentaho.di.osgi.service.notifier;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.osgi.OSGIPlugin;
 import org.pentaho.di.osgi.OSGIPluginTracker;
 import org.pentaho.di.osgi.OSGIPluginTrackerException;
 import org.pentaho.di.osgi.service.lifecycle.LifecycleEvent;
@@ -40,7 +41,7 @@ public class DelayedServiceNotifierTest {
   private Map<Class, OSGIServiceLifecycleListener> instanceListeners;
   private ScheduledExecutorService scheduler;
   private OSGIPluginTracker osgiPluginTracker;
-  private Object serviceObject;
+  private OSGIPlugin serviceObject;
   private Class<?> clazz;
   private ProxyUnwrapper proxyUnwrapper;
   private DelayedServiceNotifierListener delayedServiceNotifierListener;
@@ -50,7 +51,7 @@ public class DelayedServiceNotifierTest {
     instanceListeners = new HashMap<Class, OSGIServiceLifecycleListener>();
     scheduler = mock( ScheduledExecutorService.class );
     osgiPluginTracker = mock( OSGIPluginTracker.class );
-    serviceObject = mock( Object.class );
+    serviceObject = mock( OSGIPlugin.class );
     proxyUnwrapper = mock( ProxyUnwrapper.class );
     delayedServiceNotifierListener = mock( DelayedServiceNotifierListener.class );
     clazz = Map.class;


### PR DESCRIPTION
the KarafLifecycleListener should ensure are registered with the PluginRegistry before marking karaf startup as complete.